### PR TITLE
Relocate config option

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -71,7 +71,9 @@ component {
 			// The tag file location, realtive or absolute
 			"tagFile" = "config/_deploy.tag",
 			// The model to use for running deployment commands. Must be a valid WireBox mapping
-			"deployCommandObject" = ""
+			"deployCommandObject" = "",
+			// when a deploy is detected, location that request should be redirected to (default is none = no redirect will occur)
+			"relocateOnDeploy" = ""
 		};
 
 		// incorporate settings

--- a/interceptors/Deploy.cfc
+++ b/interceptors/Deploy.cfc
@@ -24,6 +24,7 @@ component extends="coldbox.system.Interceptor" accessors="true"{
 		// Try to locate the path
 		variables.tagFilepath 			= locateFilePath( getSetting( "autodeploy" ).tagFile );
 		variables.deployCommandObject 	= getSetting( "autoDeploy" ).deployCommandObject;
+		variables.relocateOnDeploy 		= getSetting( "autoDeploy" ).relocateOnDeploy;
 			
 		// Validate it and create it if not found.
 		if( len( variables.tagFilepath ) eq 0 ){
@@ -73,8 +74,10 @@ component extends="coldbox.system.Interceptor" accessors="true"{
 							// Mark Application for shutdown
 							applicationStop();
 
-							// Relocate to site root for this to take effect
-							location( "/", "false", "301" );
+							// Relocate if config setting has URL for this to take effect
+							if(len(variables.relocateOnDeploy)){
+								location( variables.relocateOnDeploy, "false", "302" );
+							}
 							
 						} catch( Any e ){
 							//Log Error

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,9 @@ autodeploy = {
     // The tag file location, realtive or absolute from the root of your application.
     "tagFile" : "config/_deploy.tag",
     // The model to use for running deployment commands. Must be a valid WireBox mapping
-    "deployCommandObject" :  ""
+    "deployCommandObject" :  "",
+    // A URL to redirect to when a deploy is detected. Default is none, in which case no redirect will occur (request will complete normally and app will reinit on next request).
+    "relocateOnDeploy" :  ""
 };
 ```
 


### PR DESCRIPTION
Makes relocation optional, and in the event a relocate URL is configured, redirect happens via 302 temporary to prevent caching problems.